### PR TITLE
Fix TechDraw ordinate dimensions: Add missing zero dimension at origin

### DIFF
--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -345,6 +345,17 @@ bool PropertyEnumeration::isPartOf(const char* value) const
     return _enum.contains(value);
 }
 
+bool PropertyEnumeration::isOneOf(const std::vector<const char*>& values) const
+{
+    for (const auto& value : values) {
+        if (_enum.isValue(value)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+
 const char* PropertyEnumeration::getValueAsString() const
 {
     if (!_enum.isValid()) {

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -209,6 +209,9 @@ public:
     /// checks if the property is set to a certain string value
     bool isValue(const char* value) const;
 
+    // checks if the property is set to one of the values in the vector
+    bool isOneOf(const std::vector<const char*>& values) const;
+
     /// checks if a string is included in the enumeration
     bool isPartOf(const char* value) const;
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -93,6 +93,8 @@ const char* DrawViewDimension::TypeEnums[] = {"Distance",
                                               "DistanceX",
                                               "DistanceY",
                                               "DistanceZ",
+                                              "OrdinateX",
+                                              "OrdinateY",
                                               "Radius",
                                               "Diameter",
                                               "Angle",
@@ -487,7 +489,7 @@ App::DocumentObjectExecReturn* DrawViewDimension::execute()
     // we have either or both valid References3D and References2D
     ReferenceVector references = getEffectiveReferences();
 
-    if (Type.isValue("Distance") || Type.isValue("DistanceX") || Type.isValue("DistanceY")) {
+    if (Type.isOneOf({"Distance", "DistanceX", "DistanceY", "OrdinateX", "OrdinateY"})) {
         if (getRefType() == oneEdge) {
             m_linearPoints = getPointsOneEdge(references);
         }
@@ -695,7 +697,7 @@ double DrawViewDimension::getTrueDimValue() const
 {
     double result = 0.0;
 
-    if (Type.isValue("Distance") || Type.isValue("DistanceX") || Type.isValue("DistanceY")) {
+    if (Type.isOneOf({"Distance", "DistanceX", "DistanceY", "OrdinateX", "OrdinateY"})) {
         result = measurement->length();
     }
     else if (Type.isValue("Radius")) {
@@ -722,7 +724,7 @@ double DrawViewDimension::getProjectedDimValue() const
     double result = 0.0;
     double scale = getViewPart()->getScale();
 
-    if (Type.isValue("Distance") || Type.isValue("DistanceX") || Type.isValue("DistanceY")) {
+    if (Type.isOneOf({"Distance", "DistanceX", "DistanceY", "OrdinateX", "OrdinateY"})) {
         pointPair pts = getLinearPoints();
         auto dbv = dynamic_cast<DrawBrokenView*>(getViewPart());
         if (dbv)  {
@@ -745,7 +747,7 @@ double DrawViewDimension::getProjectedDimValue() const
         if (Type.isValue("Distance")) {
             result = dimVec.Length() / scale;
         }
-        else if (Type.isValue("DistanceX")) {
+        else if (Type.isOneOf({"DistanceX", "OrdinateX"})) {
             result = fabs(dimVec.x) / scale;
         }
         else {
@@ -1827,7 +1829,7 @@ bool DrawViewDimension::validateReferenceForm() const
         return false;
     }
 
-    if (Type.isValue("Distance") || Type.isValue("DistanceX") || Type.isValue("DistanceY")) {
+    if (Type.isOneOf({"Distance", "DistanceX", "DistanceY", "OrdinateX", "OrdinateY"})) {
         if (getRefType() == oneEdge) {
             if (references.size() != 1) {
                 return false;

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -60,6 +60,8 @@ public:
         DistanceX,
         DistanceY,
         DistanceZ,
+        OrdinateX,
+        OrdinateY,
         Radius,
         Diameter,
         Angle,

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -1401,6 +1401,43 @@ protected:
     void createOrdinateDimension(const std::string& type)
     {
         specialDimension = SpecialDimension::OrdinateDistance;
+        
+        // Check if a zero ordinate dimension already exists at this point
+        bool hasZeroDimension = false;
+        if (partFeat) {
+            TechDraw::DrawPage* page = partFeat->findParentPage();
+            if (page) {
+                std::vector<App::DocumentObject*> views = page->Views.getValues();
+                for (auto* view : views) {
+                    auto* dim = dynamic_cast<TechDraw::DrawViewDimension*>(view);
+                    if (dim && dim->Type.isValue(type)) {
+                        // Check if this dimension is a zero dimension at the same point
+                        TechDraw::pointPair pp = dim->getLinearPoints();
+                        Base::Vector3d firstPoint = selPoints[0].second();
+                        if (std::abs(pp.first().x - firstPoint.x) < 1e-6 &&
+                            std::abs(pp.first().y - firstPoint.y) < 1e-6 &&
+                            std::abs(pp.second().x - firstPoint.x) < 1e-6 &&
+                            std::abs(pp.second().y - firstPoint.y) < 1e-6) {
+                            hasZeroDimension = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        
+        // Create zero dimension if it doesn't exist
+        if (!hasZeroDimension) {
+            DrawViewDimension* zeroDim = dimMaker(partFeat, type, { selPoints[0], selPoints[0] }, {});
+            dims.push_back(zeroDim);
+            // Position zero dimension text at the origin point
+            Base::Vector3d firstPoint = selPoints[0].second();
+            zeroDim->X.setValue(firstPoint.x);
+            double fontSize = Preferences::dimFontSizeMM();
+            zeroDim->Y.setValue(-firstPoint.y + 0.5 * fontSize);
+        }
+        
+        // Create dimensions from origin to other points
         for (size_t i = 0; i < selPoints.size() - 1; ++i) {
                 DrawViewDimension* dim = dimMaker(partFeat, type, { selPoints[0], selPoints[i + 1] }, {});
             dims.push_back(dim);

--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -429,6 +429,239 @@ bool CmdTechDrawExtensionInsertPrefixGroup::isActive()
 }
 
 //===========================================================================
+// TechDraw_ExtensionCreateHorizOrdinateDimension
+//===========================================================================
+
+void execCreateHorizOrdinateDimension(Gui::Command* cmd) {
+    //create a horizontal ordinate dimension
+    std::vector<Gui::SelectionObject> selection;
+    TechDraw::DrawViewPart* objFeat = nullptr;
+    if (!_checkSelObjAndSubs(cmd, selection, objFeat, QT_TRANSLATE_NOOP("QObject","TechDraw Create Horizontal Ordinate Dimension"))) {
+        return;
+    }
+
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Horiz Ordinate Dim"));
+    const std::vector<std::string> subNames = selection[0].getSubNames();
+    std::vector<dimVertex> allVertexes;
+    allVertexes = _getVertexInfo(objFeat, subNames);
+    if (!allVertexes.empty() && allVertexes.size() > 1) {
+        double dimDistance = activeDimAttributes.getCascadeSpacing();
+        double yMaster = allVertexes[0].point.y - dimDistance;
+        if (std::signbit(yMaster)){
+            dimDistance = -dimDistance;
+        }
+        for (long unsigned int n = 0; n < allVertexes.size() - 1; n++) {
+            TechDraw::DrawViewDimension* dim =
+                _createLinDimension(objFeat, allVertexes[0].name, allVertexes[n + 1].name, "OrdinateX");
+            TechDraw::pointPair pp = dim->getLinearPoints();
+            dim->X.setValue(pp.second().x);
+            dim->Y.setValue(-yMaster);
+        }
+    }
+    objFeat->refreshCEGeoms();
+    objFeat->requestPaint();
+    Gui::Command::getSelection().clearSelection();
+    Gui::Command::commitCommand();
+}
+
+DEF_STD_CMD_A(CmdTechDrawExtensionCreateHorizOrdinateDimension)
+
+CmdTechDrawExtensionCreateHorizOrdinateDimension::CmdTechDrawExtensionCreateHorizOrdinateDimension()
+    : Command("TechDraw_ExtensionCreateHorizOrdinateDimension")
+{
+    sAppModule      = "TechDraw";
+    sGroup          = QT_TR_NOOP("TechDraw");
+    sMenuText       = QT_TR_NOOP("Create Horizontal Ordinate Dimensions");
+    sToolTipText    = QT_TR_NOOP("Create a horizontally ordinate dimensions:<br>\
+- Select the first node as the 0 point<br>\
+- Then select the wanted nodes<br>\
+- Click this tool");
+    sWhatsThis      = "TechDraw_ExtensionCreateHorizOrdinateDimension";
+    sStatusTip      = sMenuText;
+    sPixmap         = "TechDraw_ExtensionCreateHorizOrdinateDimension";
+}
+
+void CmdTechDrawExtensionCreateHorizOrdinateDimension::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    execCreateHorizOrdinateDimension(this);
+}
+
+bool CmdTechDrawExtensionCreateHorizOrdinateDimension::isActive()
+{
+    bool havePage = DrawGuiUtil::needPage(this);
+    bool haveView = DrawGuiUtil::needView(this);
+    return (havePage && haveView);
+}
+
+//===========================================================================
+// TechDraw_ExtensionCreateVertOrdinateDimension
+// //===========================================================================
+void execCreateVertOrdinateDimension(Gui::Command* cmd) {
+    //create a vertical ordinate dimension
+    std::vector<Gui::SelectionObject> selection;
+    TechDraw::DrawViewPart* objFeat = nullptr;
+    if (!_checkSelObjAndSubs(cmd, selection, objFeat, QT_TRANSLATE_NOOP("QObject","TechDraw Create Vertical Ordinate Dimension"))) {
+        return;
+    }
+
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Horiz Ordinate Dim"));
+    const std::vector<std::string> subNames = selection[0].getSubNames();
+    std::vector<dimVertex> allVertexes;
+    allVertexes = _getVertexInfo(objFeat, subNames);
+    if (!allVertexes.empty() && allVertexes.size() > 1) {
+        double dimDistance = activeDimAttributes.getCascadeSpacing();
+        double xMaster = allVertexes[0].point.x - dimDistance;
+        if (std::signbit(xMaster)){
+            dimDistance = -dimDistance;
+        }
+        for (long unsigned int n = 0; n < allVertexes.size() - 1; n++) {
+            TechDraw::DrawViewDimension* dim =
+                _createLinDimension(objFeat, allVertexes[0].name, allVertexes[n + 1].name, "OrdinateY");
+            TechDraw::pointPair pp = dim->getLinearPoints();
+            dim->X.setValue(xMaster);
+            dim->Y.setValue(-pp.second().y);
+        }
+    }
+    objFeat->refreshCEGeoms();
+    objFeat->requestPaint();
+    Gui::Command::getSelection().clearSelection();
+    Gui::Command::commitCommand();
+}
+
+DEF_STD_CMD_A(CmdTechDrawExtensionCreateVertOrdinateDimension)
+
+CmdTechDrawExtensionCreateVertOrdinateDimension::CmdTechDrawExtensionCreateVertOrdinateDimension()
+    : Command("TechDraw_ExtensionCreateVertOrdinateDimension")
+{
+    sAppModule      = "TechDraw";
+    sGroup          = QT_TR_NOOP("TechDraw");
+    sMenuText       = QT_TR_NOOP("Create Vertical Ordinate Dimensions");
+    sToolTipText    = QT_TR_NOOP("Create a vertically ordinate dimensions:<br>\
+- Select the first node as the 0 point<br>\
+- Then select the wanted nodes<br>\
+- Click this tool");
+    sWhatsThis      = "TechDraw_ExtensionCreateVertOrdinateDimension";
+    sStatusTip      = sMenuText;
+    sPixmap         = "TechDraw_ExtensionCreateVertOrdinateDimension";
+}
+
+void CmdTechDrawExtensionCreateVertOrdinateDimension::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    execCreateVertOrdinateDimension(this);
+}
+
+bool CmdTechDrawExtensionCreateVertOrdinateDimension::isActive()
+{
+    bool havePage = DrawGuiUtil::needPage(this);
+    bool haveView = DrawGuiUtil::needView(this);
+    return (havePage && haveView);
+}
+//===========================================================================
+// TechDraw_ExtensionCreateOrdinateDimensionGroup
+//===========================================================================
+
+DEF_STD_CMD_ACL(CmdTechDrawExtensionCreateOrdinateDimensionGroup)
+
+CmdTechDrawExtensionCreateOrdinateDimensionGroup::CmdTechDrawExtensionCreateOrdinateDimensionGroup()
+    : Command("TechDraw_ExtensionCreateOrdinateDimensionGroup")
+{
+    sAppModule      = "TechDraw";
+    sGroup          = QT_TR_NOOP("TechDraw");
+    sMenuText       = QT_TR_NOOP("Create an ordinate dimension");
+    sToolTipText    = QT_TR_NOOP("Create an ordinate dimension:<br>\
+- Select two or more nodes<br>\
+- Click this tool");
+    sWhatsThis      = "TechDraw_ExtensionGroup";
+    sStatusTip      = sMenuText;
+}
+
+void CmdTechDrawExtensionCreateOrdinateDimensionGroup::activated(int iMsg)
+{
+    //    Base::Console().Message("CMD::ExtensionLinePPGroup - activated(%d)\n", iMsg);
+    Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
+    if (dlg != nullptr) {
+        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Task In Progress"),
+            QObject::tr("Close active task dialog and try again."));
+        return;
+    }
+
+    auto* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
+    pcAction->setIcon(pcAction->actions().at(iMsg)->icon());
+    switch (iMsg) {
+    case 0:
+        execCreateHorizOrdinateDimension(this);
+        break;
+    case 1:
+        execCreateVertOrdinateDimension(this);
+        break;
+    default:
+        Base::Console().Message("CMD::CVGrp - invalid iMsg: %d\n", iMsg);
+    };
+}
+
+Gui::Action* CmdTechDrawExtensionCreateOrdinateDimensionGroup::createAction()
+{
+    auto* pcAction = new Gui::ActionGroup(this, Gui::getMainWindow());
+    pcAction->setDropDownMenu(true);
+    applyCommandData(this->className(), pcAction);
+
+    QAction* p1 = pcAction->addAction(QString());
+    p1->setIcon(Gui::BitmapFactory().iconFromTheme("TechDraw_ExtensionCreateHorizOrdinateDimension"));
+    p1->setObjectName(QString::fromLatin1("TechDraw_ExtensionCreateHorizOrdinateDimension"));
+    p1->setWhatsThis(QString::fromLatin1("TechDraw_ExtensionCreateHorizOrdinateDimension"));
+    QAction* p2 = pcAction->addAction(QString());
+    p2->setIcon(Gui::BitmapFactory().iconFromTheme("TechDraw_ExtensionCreateVertOrdinateDimension"));
+    p2->setObjectName(QString::fromLatin1("TechDraw_ExtensionCreateVertOrdinateDimension"));
+    p2->setWhatsThis(QString::fromLatin1("TechDraw_ExtensionCreateVertOrdinateDimension"));
+
+    _pcAction = pcAction;
+    languageChange();
+
+    pcAction->setIcon(p1->icon());
+    int defaultId = 0;
+    pcAction->setProperty("defaultAction", QVariant(defaultId));
+
+    return pcAction;
+}
+
+void CmdTechDrawExtensionCreateOrdinateDimensionGroup::languageChange()
+{
+    Command::languageChange();
+
+    if (!_pcAction) {
+        return;
+    }
+    auto* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
+    QList<QAction*> a = pcAction->actions();
+
+    QAction* arc1 = a[0];
+    arc1->setText(QApplication::translate("CmdTechDrawExtensionCreateHorizOrdinateDimension", "Create Horizontal Ordinate Dimension"));
+    arc1->setToolTip(QApplication::translate("CmdTechDrawExtensionCreateHorizOrdinateDimension",
+"Insert a horizontally ordinate dimension:<br>\
+- Select the first node as the 0 point<br>\
+- Then select the wanted nodes<br>\
+- Click this tool"));
+    arc1->setStatusTip(arc1->text());
+    QAction* arc2 = a[1];
+    arc2->setText(QApplication::translate("CmdTechDrawExtensionCreateVertOrdinateDimension", "Create Vertical Ordinate Dimension"));
+    arc2->setToolTip(QApplication::translate("CmdTechDrawExtensionCreateVertOrdinateDimension",
+"Insert a vertically ordinate dimension:<br>\
+- Select the first node as the 0 point<br>\
+- Then select the wanted nodes<br>\
+- Click this tool"));
+    arc2->setStatusTip(arc2->text());
+}
+
+bool CmdTechDrawExtensionCreateOrdinateDimensionGroup::isActive()
+{
+    bool havePage = DrawGuiUtil::needPage(this);
+    bool haveView = DrawGuiUtil::needView(this, true);
+    return (havePage && haveView);
+}
+
+//===========================================================================
 // TechDraw_ExtensionIncreaseDecimal
 //===========================================================================
 
@@ -2537,6 +2770,9 @@ void CreateTechDrawCommandsExtensionDims()
 {
     Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
 
+    rcCmdMgr.addCommand(new CmdTechDrawExtensionCreateOrdinateDimensionGroup());
+    rcCmdMgr.addCommand(new CmdTechDrawExtensionCreateHorizOrdinateDimension());
+    rcCmdMgr.addCommand(new CmdTechDrawExtensionCreateVertOrdinateDimension());
     rcCmdMgr.addCommand(new CmdTechDrawExtensionInsertPrefixGroup());
     rcCmdMgr.addCommand(new CmdTechDrawExtensionInsertDiameter());
     rcCmdMgr.addCommand(new CmdTechDrawExtensionInsertSquare());

--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -450,6 +450,37 @@ void execCreateHorizOrdinateDimension(Gui::Command* cmd) {
         if (std::signbit(yMaster)){
             dimDistance = -dimDistance;
         }
+        
+        // Check if a zero ordinate dimension already exists at this point
+        bool hasZeroDimension = false;
+        TechDraw::DrawPage* page = objFeat->findParentPage();
+        if (page) {
+            std::vector<App::DocumentObject*> views = page->Views.getValues();
+            for (auto* view : views) {
+                auto* dim = dynamic_cast<TechDraw::DrawViewDimension*>(view);
+                if (dim && dim->Type.isValue("OrdinateX")) {
+                    // Check if this dimension is a zero dimension at the same point
+                    TechDraw::pointPair pp = dim->getLinearPoints();
+                    if (std::abs(pp.first().x - allVertexes[0].point.x) < 1e-6 &&
+                        std::abs(pp.first().y - allVertexes[0].point.y) < 1e-6 &&
+                        std::abs(pp.second().x - allVertexes[0].point.x) < 1e-6 &&
+                        std::abs(pp.second().y - allVertexes[0].point.y) < 1e-6) {
+                        hasZeroDimension = true;
+                        break;
+                    }
+                }
+            }
+        }
+        
+        // Create zero dimension if it doesn't exist
+        if (!hasZeroDimension) {
+            TechDraw::DrawViewDimension* zeroDim =
+                _createLinDimension(objFeat, allVertexes[0].name, allVertexes[0].name, "OrdinateX");
+            zeroDim->X.setValue(allVertexes[0].point.x);
+            zeroDim->Y.setValue(-yMaster);
+        }
+        
+        // Create dimensions from origin to other points
         for (long unsigned int n = 0; n < allVertexes.size() - 1; n++) {
             TechDraw::DrawViewDimension* dim =
                 _createLinDimension(objFeat, allVertexes[0].name, allVertexes[n + 1].name, "OrdinateX");
@@ -505,7 +536,7 @@ void execCreateVertOrdinateDimension(Gui::Command* cmd) {
         return;
     }
 
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Horiz Ordinate Dim"));
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Create Vert Ordinate Dim"));
     const std::vector<std::string> subNames = selection[0].getSubNames();
     std::vector<dimVertex> allVertexes;
     allVertexes = _getVertexInfo(objFeat, subNames);
@@ -515,6 +546,37 @@ void execCreateVertOrdinateDimension(Gui::Command* cmd) {
         if (std::signbit(xMaster)){
             dimDistance = -dimDistance;
         }
+        
+        // Check if a zero ordinate dimension already exists at this point
+        bool hasZeroDimension = false;
+        TechDraw::DrawPage* page = objFeat->findParentPage();
+        if (page) {
+            std::vector<App::DocumentObject*> views = page->Views.getValues();
+            for (auto* view : views) {
+                auto* dim = dynamic_cast<TechDraw::DrawViewDimension*>(view);
+                if (dim && dim->Type.isValue("OrdinateY")) {
+                    // Check if this dimension is a zero dimension at the same point
+                    TechDraw::pointPair pp = dim->getLinearPoints();
+                    if (std::abs(pp.first().x - allVertexes[0].point.x) < 1e-6 &&
+                        std::abs(pp.first().y - allVertexes[0].point.y) < 1e-6 &&
+                        std::abs(pp.second().x - allVertexes[0].point.x) < 1e-6 &&
+                        std::abs(pp.second().y - allVertexes[0].point.y) < 1e-6) {
+                        hasZeroDimension = true;
+                        break;
+                    }
+                }
+            }
+        }
+        
+        // Create zero dimension if it doesn't exist
+        if (!hasZeroDimension) {
+            TechDraw::DrawViewDimension* zeroDim =
+                _createLinDimension(objFeat, allVertexes[0].name, allVertexes[0].name, "OrdinateY");
+            zeroDim->X.setValue(xMaster);
+            zeroDim->Y.setValue(-allVertexes[0].point.y);
+        }
+        
+        // Create dimensions from origin to other points
         for (long unsigned int n = 0; n < allVertexes.size() - 1; n++) {
             TechDraw::DrawViewDimension* dim =
                 _createLinDimension(objFeat, allVertexes[0].name, allVertexes[n + 1].name, "OrdinateY");

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.h
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.h
@@ -272,6 +272,7 @@ protected:
                              double centerOverhang, int standardStyle, int renderExtent, bool flipArrow) const;
 
     void drawDistance(TechDraw::DrawViewDimension *dimension, ViewProviderDimension *viewProvider) const;
+    void drawOrdinate(TechDraw::DrawViewDimension *dimension, ViewProviderDimension *viewProvider) const;
     void drawRadius(TechDraw::DrawViewDimension *dimension, ViewProviderDimension *viewProvider) const;
     void drawDiameter(TechDraw::DrawViewDimension *dimension, ViewProviderDimension *viewProvider) const;
     void drawAngle(TechDraw::DrawViewDimension *dimension, ViewProviderDimension *viewProvider) const;
@@ -302,6 +303,9 @@ private:
     static double toDeg(double angle);
     static double toQtRad(double angle);
     static double toQtDeg(double angle);
+
+    bool isHorizontal(const Base::Vector2d &a, const Base::Vector2d &b) const;
+    bool isVertical(const Base::Vector2d &a, const Base::Vector2d &b) const;
 
     double getDefaultExtensionLineOverhang() const;
     double getDefaultArrowTailLength() const;

--- a/src/Mod/TechDraw/Gui/Resources/TechDraw.qrc
+++ b/src/Mod/TechDraw/Gui/Resources/TechDraw.qrc
@@ -164,6 +164,8 @@
         <file>icons/TechDraw_TreeSpreadsheet.svg</file>
         <file>icons/TechDraw_TreeSymbol.svg</file>
         <file>icons/TechDraw_TreeView.svg</file>
+        <file>icons/TechDraw_ExtensionCreateHorizOrdinateDimension.svg</file>
+        <file>icons/TechDraw_ExtensionCreateVertOrdinateDimension.svg</file>
         <file>icons/TechDraw_VerticalDimension.svg</file>
         <file>icons/TechDraw_VerticalExtentDimension.svg</file>
         <file>icons/TechDraw_RefError.svg</file>

--- a/src/Mod/TechDraw/Gui/Resources/icons/TechDraw_ExtensionCreateHorizOrdinateDimension.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/TechDraw_ExtensionCreateHorizOrdinateDimension.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666665 8.466667"
+   version="1.1"
+   id="svg1876"
+   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   sodipodi:docname="TechDraw_ExtensionCreateHorizOrdinateDimension.svg"
+   style="enable-background:new"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1870">
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect1900"
+       is_visible="true"
+       offset_points="0,0.095902298"
+       sort_points="true"
+       interpolator_type="CubicBezierJohan"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="extrp_arc"
+       miter_limit="4"
+       end_linecap_type="zerowidth" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1958"
+       x="-0.06310238"
+       y="-0.06310238"
+       width="1.1262048"
+       height="1.1262048">
+      <feBlend
+         inkscape:collect="always"
+         mode="exclusion"
+         in2="BackgroundImage"
+         id="feBlend1960" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.7948625"
+     inkscape:cx="40.042858"
+     inkscape:cy="-5.3181921"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g883"
+     showgrid="false"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:snap-global="false"
+     showguides="true"
+     inkscape:window-width="2160"
+     inkscape:window-height="1320"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata1873">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Livello 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-288.53332)"
+     style="filter:url(#filter1958)">
+    <g
+       id="g883"
+       transform="matrix(1.0090344,0,0,1.0090344,3.4111984,-1.3731438)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path1469"
+         d="m 3.7186198,291.53054 v -3.12722"
+         style="fill:#ffff00;fill-opacity:1;stroke:#ff0000;stroke-width:0.335019;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path829"
+         d="m -1.9260066,289.87798 h 3.7058313 l 1.6702743,1.70471 v 3.75381 h -5.3761056"
+         style="fill:none;stroke:#ffff00;stroke-width:0.515414;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path872"
+         d="m -1.7564287,289.53975 v -1.13643"
+         style="fill:#ffff00;fill-opacity:1;stroke:#ff0000;stroke-width:0.335019;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <circle
+         style="opacity:1;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:0.563823;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:10.1537;stroke-opacity:1;filter:url(#filter1958);enable-background:new"
+         id="circle874"
+         cx="2.5219917"
+         cy="-12.686612"
+         r="2.2337627"
+         transform="matrix(0.27274012,-1.3580413e-4,1.3580413e-4,0.27274012,-2.4271891,291.52105)" />
+      <path
+         style="fill:#ffff00;fill-opacity:1;stroke:#ff0000;stroke-width:0.335019;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 1.7893623,289.53975 v -1.13643"
+         id="path1465"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <circle
+         transform="matrix(0.27274012,-1.3580413e-4,1.3580413e-4,0.27274012,1.1186019,291.52105)"
+         r="2.2337627"
+         cy="-12.686612"
+         cx="2.5219917"
+         id="circle1467"
+         style="opacity:1;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:0.563823;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:10.1537;stroke-opacity:1;filter:url(#filter1958);enable-background:new" />
+      <circle
+         style="opacity:1;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:0.563823;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:10.1537;stroke-opacity:1;filter:url(#filter1958);enable-background:new"
+         id="circle1471"
+         cx="2.5219917"
+         cy="-12.686612"
+         r="2.2337627"
+         transform="matrix(0.27274012,-1.3580413e-4,1.3580413e-4,0.27274012,3.0478594,291.52105)" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path19916"
+         d="m -1.9264661,290.21276 h 3.5708049 l 1.4741395,1.50284 v 3.2926 h -5.0449444"
+         style="fill:none;stroke:#000000;stroke-width:0.14865697;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path19918"
+         d="m -1.9238119,289.54003 h 3.8297355 l 1.8853798,1.95943 v 4.07524 h -5.7151153"
+         style="fill:none;stroke:#000000;stroke-width:0.148657;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/TechDraw_ExtensionCreateVertOrdinateDimension.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/TechDraw_ExtensionCreateVertOrdinateDimension.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 8.4666665 8.466667"
+   version="1.1"
+   id="svg1876"
+   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   sodipodi:docname="TechDraw_ExtensionCreateVertOrdinateDimension.svg"
+   style="enable-background:new"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1870">
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect1900"
+       is_visible="true"
+       offset_points="0,0.095902298"
+       sort_points="true"
+       interpolator_type="CubicBezierJohan"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="extrp_arc"
+       miter_limit="4"
+       end_linecap_type="zerowidth" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1958"
+       x="-0.06310238"
+       y="-0.06310238"
+       width="1.1262048"
+       height="1.1262048">
+      <feBlend
+         inkscape:collect="always"
+         mode="exclusion"
+         in2="BackgroundImage"
+         id="feBlend1960" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="19.49173"
+     inkscape:cx="30.474462"
+     inkscape:cy="23.471492"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g883"
+     showgrid="false"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:snap-global="false"
+     showguides="true"
+     inkscape:window-width="2160"
+     inkscape:window-height="1320"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata1873">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Livello 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-288.53332)"
+     style="filter:url(#filter1958)">
+    <g
+       id="g883"
+       transform="translate(0.45704894,0.04755781)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path872"
+         d="M 1.4451232,289.45559 H 6.7382269"
+         style="fill:#ffff00;fill-opacity:1;stroke:#ff0000;stroke-width:0.375742;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path829"
+         d="M -0.38320702,289.64235 H 1.3259663 l 1.8733315,1.91104 v 4.20816 h -3.58250482"
+         style="fill:none;stroke:#ffff00;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path866"
+         d="M 3.4983536,295.9591 H 6.7382269"
+         style="fill:#ffff00;fill-opacity:1;stroke:#ff0000;stroke-width:0.375742;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <circle
+         style="opacity:1;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:0.563823;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:10.1537;stroke-opacity:1;filter:url(#filter1958);enable-background:new"
+         id="circle1597"
+         cx="2.5219917"
+         cy="-12.686612"
+         r="2.2337627"
+         transform="matrix(1.5231142e-4,0.30589227,-0.30589227,1.5231142e-4,3.2415266,295.2068)" />
+      <path
+         style="fill:#ffff00;fill-opacity:1;stroke:#ff0000;stroke-width:0.375742;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 3.4983536,291.56939 H 6.7382269"
+         id="path868"
+         inkscape:connector-curvature="0" />
+      <circle
+         transform="matrix(1.5231142e-4,0.30589227,-0.30589227,1.5231142e-4,3.2415266,290.81709)"
+         r="2.2337627"
+         cy="-12.686612"
+         cx="2.5219917"
+         id="circle870"
+         style="opacity:1;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:0.563823;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:10.1537;stroke-opacity:1;filter:url(#filter1958);enable-background:new" />
+      <circle
+         style="opacity:1;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#ff0000;stroke-width:0.563823;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:10.1537;stroke-opacity:1;filter:url(#filter1958);enable-background:new"
+         id="circle874"
+         cx="2.5219917"
+         cy="-12.686612"
+         r="2.2337627"
+         transform="matrix(1.5231142e-4,0.30589227,-0.30589227,1.5231142e-4,3.2415266,288.7033)" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path3709"
+         d="M -0.36884345,289.93954 H 1.2400427 l 1.6883139,1.72977 v 3.78221 h -3.29671154"
+         style="fill:none;stroke:#000000;stroke-width:0.15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path3807"
+         d="M -0.38408895,289.34394 H 1.4373086 l 2.076287,2.10067 v 4.62707 h -3.88943632"
+         style="fill:none;stroke:#000000;stroke-width:0.15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -154,6 +154,8 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     *tooldimensions << "TechDraw_ExtensionCreateHorizChamferDimension";
     *tooldimensions << "TechDraw_ExtensionCreateVertChamferDimension";
     *tooldimensions << "TechDraw_ExtensionCreateLengthArc";
+    *tooldimensions << "TechDraw_ExtensionCreateHorizOrdinateDimension";
+    *tooldimensions << "TechDraw_ExtensionCreateVertOrdinateDimension";
     *tooldimensions << "Separator";
     *tooldimensions << "TechDraw_ExtensionInsertDiameter";
     *tooldimensions << "TechDraw_ExtensionInsertSquare";
@@ -371,6 +373,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     }
     *extdimensions << "TechDraw_ExtensionInsertPrefixGroup";
     *extdimensions << "TechDraw_ExtensionIncreaseDecreaseGroup";
+    // *extdimensions << "TechDraw_ExtensionCreateOrdinateDimensionGroup";
 
     Gui::ToolBarItem* file = new Gui::ToolBarItem(root);
     file->setCommand("TechDraw File Access");
@@ -471,6 +474,7 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *extdimensions << "TechDraw_ExtensionCreateLengthArc";
     *extdimensions << "TechDraw_ExtensionInsertPrefixGroup";
     *extdimensions << "TechDraw_ExtensionIncreaseDecreaseGroup";
+    // *extdimensions << "TechDraw_ExtensionCreateOrdinateDimensionGroup";
 
     Gui::ToolBarItem* file = new Gui::ToolBarItem(root);
     file->setCommand("TechDraw File Access");


### PR DESCRIPTION
## Summary

This PR fixes a critical issue in TechDraw ordinate dimensions where the zero reference dimension was missing at the origin point. According to proper drafting standards, ordinate dimensions should always include a zero dimension at the reference point to clearly indicate the origin from which all measurements are taken.

## Problem Description

When creating ordinate dimensions in FreeCAD TechDraw, only dimensions from the origin to other selected points were created, but no zero dimension was placed at the origin itself. This made it unclear where the reference point was located and violated standard drafting practices.

## Changes Made

### Files Modified:
- `src/Mod/TechDraw/Gui/CommandExtensionDims.cpp`
- `src/Mod/TechDraw/Gui/CommandCreateDims.cpp`

### Key Improvements:

1. **Zero Dimension Creation**: Automatically creates a zero ordinate dimension at the origin point
2. **Duplicate Prevention**: Implements checking to prevent multiple zero dimensions at the same location
3. **Proper Positioning**: Ensures zero dimension text is positioned correctly at origin coordinates
4. **Type-Specific Checking**: Only checks for dimensions of the same type (OrdinateX vs OrdinateY)
5. **Bug Fix**: Corrected command name typo in vertical ordinate dimension function
6. **Backward Compatibility**: Maintains existing functionality while adding the missing feature

## Technical Details

- Uses tolerance-based comparison (1e-6) for floating-point coordinate matching
- Checks existing dimensions on the page to prevent duplicates
- Creates zero dimension using the same vertex as both start and end points
- Applies consistent logic across both extension and interactive dimension creation workflows

## Testing

The logic has been validated with a simplified test program that confirms:
- Zero dimensions are created when needed
- Duplicate zero dimensions are prevented
- Multiple calls with the same origin work correctly

## Standards Compliance

This fix ensures FreeCAD TechDraw ordinate dimensions comply with standard drafting practices where:
- The origin point is clearly marked with a zero dimension
- All other dimensions reference from this clearly defined zero point
- The dimensioning system is unambiguous and professional

## Impact

- **Users**: Will now see proper ordinate dimensions with clear zero reference points
- **Compatibility**: No breaking changes to existing workflows
- **Standards**: Brings FreeCAD in line with industry drafting standards

---

### Previous Work

This PR builds upon the existing ordinate dimension implementation that included:
- Icons for Vert and Horiz Ordinate Dimensions
- Menu and toolbar icons and tooltips
- Icon colors and design refinements
- Spelling corrections ("Ordinated" to "Ordinate")

The current changes specifically address the missing zero dimension functionality that is essential for proper ordinate dimensioning.